### PR TITLE
fix: updated bug related to REVERSE_PROXY env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Hello Universe is available as a Docker image.
 To run Hello Universe issue the following commands:
 
 ```shell
-docker pull ghcr.io/spectrocloud/hello-universe:1.0.5
-docker run -p 8080:8080 ghcr.io/spectrocloud/hello-universe:1.0.5
+docker pull ghcr.io/spectrocloud/hello-universe:1.0.6
+docker run -p 8080:8080 ghcr.io/spectrocloud/hello-universe:1.0.6
 ```
 
 ## Non-Docker
@@ -54,7 +54,7 @@ API_URI=http://localhost:3000
 If you are using the Docker image then use the `-e` flag parameter.
 
 ```shell
-docker run -p 8080:8080 -e API_URI=http://localhost:3000 ghcr.io/spectrocloud/hello-universe:1.0.5
+docker run -p 8080:8080 -e API_URI=http://localhost:3000 ghcr.io/spectrocloud/hello-universe:1.0.6
 ```
 
 ### Reverse Proxy
@@ -63,7 +63,7 @@ A Docker container with a reverse proxy for `http://0.0.0.0:3000` is available. 
 hello universe application into a Kubernetes cluster or similar architectures and need the UI to route requests internal to the hosting platform. An example of such behavior is needing to to reach a private API inside the Kubernetes cluster. **The reverse proxy expects the API to be listening on port `3000`.**
 
 ```shell
-docker run -p 8080:8080 -p 3000:3000  -e API_URI="http://myprivate.api.address.example:3000"  ghcr.io/spectrocloud/hello-universe:1.0.5-proxy
+docker run -p 8080:8080 -p 3000:3000  -e API_URI="http://myprivate.api.address.example:3000"  ghcr.io/spectrocloud/hello-universe:1.0.6-proxy
 ```
 
 # Development

--- a/src/App.js
+++ b/src/App.js
@@ -26,7 +26,7 @@ function App() {
       API_URI = ""
   }
 
-  if (REVERSE_PROXY) {
+  if (REVERSE_PROXY === "true") {
       API_URI = "http://0.0.0.0:3000"
   }
 


### PR DESCRIPTION
Ths bug fixes the bug where the reverse proxy env variable was always defaulting to true and setting the API_URL to `0.0.0.0:3000`