### PR TITLE
fix: added ability for reverse proxy to insert auth token in request

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,39 +1,41 @@
 {
-        debug
+	debug
 }
 :8080 {
-        encode gzip
-        handle_path /api/* {
-                reverse_proxy {$API_URI}
-        }
-
-        handle {
-                root * /app/build
-                try_files {path} /index.html
-                file_server
-        }
-	log {
-		output file /var/log/caddy/caddy.log {
-			roll_size 1gb
-            roll_keep 2
-            roll_keep_for 720h
-		}
-		format json {
-            time_format wall
-        }
+	encode gzip
+	handle_path /api/* {
+		reverse_proxy {$API_URI}
 	}
 
-}
-:3000 {
-   reverse_proxy {$SVC_URI}
+	handle {
+		root * /app/build
+		try_files {path} /index.html
+		file_server
+	}
 	log {
 		output file /var/log/caddy/caddy.log {
 			roll_size 1gb
-            roll_keep 2
-            roll_keep_for 720h
+			roll_keep 2
+			roll_keep_for 720h
 		}
 		format json {
-            time_format wall
-        }
+			time_format wall
+		}
+	}
+}
+:3000 {
+	reverse_proxy /api/* {
+		header_up Authorization "Bearer {$TOKEN}"
+		to {$SVC_URI}
+	}
+	log {
+		output file /var/log/caddy/caddy.log {
+			roll_size 1gb
+			roll_keep 2
+			roll_keep_for 720h
+		}
+		format json {
+			time_format wall
+		}
 	}
 }

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Hello Universe is available as a Docker image.
 To run Hello Universe issue the following commands:
 
 ```shell
-docker pull ghcr.io/spectrocloud/hello-universe:1.0.6
-docker run -p 8080:8080 ghcr.io/spectrocloud/hello-universe:1.0.6
+docker pull ghcr.io/spectrocloud/hello-universe:1.0.7
+docker run -p 8080:8080 ghcr.io/spectrocloud/hello-universe:1.0.7
 ```
 
 ## Non-Docker
@@ -56,7 +56,7 @@ API_URI=http://localhost:3000
 If you are using the Docker image then use the `-e` flag parameter.
 
 ```shell
-docker run -p 8080:8080 -e API_URI=http://localhost:3000 ghcr.io/spectrocloud/hello-universe:1.0.6
+docker run -p 8080:8080 -e API_URI=http://localhost:3000 ghcr.io/spectrocloud/hello-universe:1.0.7
 ```
 
 ### Reverse Proxy

--- a/local-caddyfile
+++ b/local-caddyfile
@@ -1,24 +1,20 @@
-:8080 {
-	encode gzip
-	handle_path /api/* {
-		reverse_proxy http://0.0.0.0:3000
+{
+	debug
+}
+:3000 {
+	reverse_proxy /api/* {
+		header_up Authorization "Bearer {$TOKEN}"
+		to {$SVC_URI}
 	}
-
-	handle {
-		root * build/
-		try_files {path} /index.html
-		file_server	
-	}
-
+	
 	log {
 		output file caddy.log {
 			roll_size 1gb
-            roll_keep 2
-            roll_keep_for 720h
+			roll_keep 2
+			roll_keep_for 720h
 		}
 		format json {
-            time_format wall
-        }
+			time_format wall
+		}
 	}
-
 }


### PR DESCRIPTION
This PR adds the ability for the Caddy server to inject the auth token in the API requests through the reverse proxy.