### PR TITLE
docs: fix targe branch for dependabot DOC-2077

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    target-branch: "master"
+    target-branch: "main"
     commit-message:
       prefix: "chore:"
 
@@ -12,6 +12,6 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    target-branch: "master"
+    target-branch: "main"
     commit-message:
       prefix: "chore:"


### PR DESCRIPTION
## Describe the Change

This PR updates the dependabot target branch from master to main.

## Review Changes

🎫 [DOC-2077](https://spectrocloud.atlassian.net/browse/DOC-2077)
