### PR TITLE
chore: add permissions for github token

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - doc-2252-security
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,7 +5,6 @@ on:
     types: ["synchronize", "opened", "reopened", "ready_for_review"]
     branches:
       - main
-      - doc-2252-security
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -1,4 +1,4 @@
-branches: [main, doc-2252-security]
+branches: [main]
 repositoryUrl: https://github.com/spectrocloud/hello-universe
 plugins:
   - "@semantic-release/commit-analyzer"


### PR DESCRIPTION
## Describe the Change

This PR adds permissions to limit the scope of GITHUH_TOKEN.

Note: I tested the changes for the `gitleaks.yaml` and `test.yaml` workflows, but for the `release.yaml` one, I will merge the PR and monitor the release process closely.

## Review Changes

🎫 [DOC-2252](https://spectrocloud.atlassian.net/browse/DOC-2252)


[DOC-2252]: https://spectrocloud.atlassian.net/browse/DOC-2252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ